### PR TITLE
Update the ios dependency to the correct npm name

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
 
     <!-- ios -->
     <platform name="ios">
-        <dependency id="de.appplant.cordova.common.registerusernotificationsettings" />
+        <dependency id="cordova-plugin-registerusernotificationsettings" />
         <config-file target="config.xml" parent="/*">
             <feature name="LocalNotification">
                 <param name="ios-package" value="APPLocalNotification" onload="true" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -128,7 +128,7 @@
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>
 
-        <lib-file src="libs/android/android-support-v4.jar" />
+        <framework src="com.android.support:support-v4:+" />
 
         <source-file
             src="src/android/LocalNotification.java"

--- a/src/ios/AppDelegate+APPLocalNotificationAction.h
+++ b/src/ios/AppDelegate+APPLocalNotificationAction.h
@@ -10,7 +10,10 @@
  @interface AppDelegate (APPLocalNotificationAction)
 
 // Handle notification actions for iOS < 9
- - (void) application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotificiation:(UILocalNotification *)notification completionHandler:(void(^)())completionHandler;
+- (void)            application:(UIApplication *)application
+     handleActionWithIdentifier:(NSString *)identifier
+           forLocalNotification:(UILocalNotification *)notification
+              completionHandler:(void (^)(void))completionHandler;
 
 //  Handle notification actions with optional response info for iOS >= 9
  - (void) application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;   

--- a/src/ios/AppDelegate+APPLocalNotificationAction.m
+++ b/src/ios/AppDelegate+APPLocalNotificationAction.m
@@ -12,7 +12,10 @@
 /**
  * Handle notification actions for iOS < 9.
  */
- - (void) application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotificiation:(UILocalNotification *)notification completionHandler:(void(^)())completionHandler;
+- (void)            application:(UIApplication *)application
+     handleActionWithIdentifier:(NSString *)identifier
+           forLocalNotification:(UILocalNotification *)notification
+              completionHandler:(void (^)(void))completionHandler
  {
  	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:notification forKey:@"localNotification"];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"SendActionIdentifier" object:identifier userInfo:userInfo];


### PR DESCRIPTION
The plugin is now called `de.appplant.cordova.common.registerusernotificationsettings`
https://www.npmjs.com/package/cordova-plugin-registerusernotificationsettings

I would use the base fork, but unfortunately, https://github.com/katzer/cordova-plugin-local-notifications is still at version 0.8.4.

In the meanwhile, if we want to use actions, we need to use your copy...