### PR TITLE
Update the ios dependency to the correct npm name

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
 
     <!-- ios -->
     <platform name="ios">
-        <dependency id="de.appplant.cordova.common.registerusernotificationsettings" />
+        <dependency id="cordova-plugin-registerusernotificationsettings" />
         <config-file target="config.xml" parent="/*">
             <feature name="LocalNotification">
                 <param name="ios-package" value="APPLocalNotification" onload="true" />


### PR DESCRIPTION
The plugin is now called de.appplant.cordova.common.registerusernotificationsettings
https://www.npmjs.com/package/cordova-plugin-registerusernotificationsettings

I would use the base fork, but unfortunately, https://github.com/katzer/cordova-plugin-local-notifications is still at version 0.8.4.

In the meanwhile, if we want to use actions, we need to use your copy...
